### PR TITLE
Add CV Master link

### DIFF
--- a/gpts.html
+++ b/gpts.html
@@ -52,6 +52,15 @@
                 Launch GPT
             </a>
         </section>
+
+        <section class="hero gpt-hero">
+            <h2>CV Master: UK Edition</h2>
+            <a href="https://chatgpt.com/g/g-686d91cc8a148191aced55a21d7c47cb-cv-master-uk-edition"
+               class="primary-cta" target="_blank" rel="noopener noreferrer"
+               aria-label="Launch CV Master: UK Edition GPT in ChatGPT">
+                Launch GPT
+            </a>
+        </section>
     </main>
 
     <footer role="contentinfo">


### PR DESCRIPTION
## Summary
- include CV Master: UK Edition link on the GPTs page

## Testing
- `apt-get install -y tidy` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_687192a73ae4832ab2a12c746bc14c19